### PR TITLE
Stop shadowing builtins

### DIFF
--- a/benchmarks/detection.py
+++ b/benchmarks/detection.py
@@ -32,7 +32,7 @@ def test_save_frame_with_annotation(benchmark, image_camera, temp_image_file):
 @pytest.mark.parametrize("filename", IMAGE_DATA.keys())
 def test_process_frame(filename, benchmark, temp_image_file):
     class TestCamera(ImageFileCamera):
-        def get_marker_size(self, id):
+        def get_marker_size(self, marker_id):
             return 100
 
     camera = TestCamera(
@@ -44,7 +44,7 @@ def test_process_frame(filename, benchmark, temp_image_file):
 @pytest.mark.parametrize("filename,camera_name", IMAGE_DATA.items())
 def test_process_frame_eager(filename, camera_name, benchmark, temp_image_file):
     class TestCamera(ImageFileCamera):
-        def get_marker_size(self, id):
+        def get_marker_size(self, marker_id):
             return 100
 
     camera = TestCamera(

--- a/poetry.lock
+++ b/poetry.lock
@@ -156,6 +156,17 @@ pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
 category = "dev"
+description = "Check for python builtins being used as variables or parameters."
+name = "flake8-builtins"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[package.dependencies]
+flake8 = "*"
+
+[[package]]
+category = "dev"
 description = "A flake8 plugin to help you write better list/set/dict comprehensions."
 name = "flake8-comprehensions"
 optional = false
@@ -593,7 +604,7 @@ version = "0.5.2"
 rpi = ["picamera"]
 
 [metadata]
-content-hash = "44073ef3919b06a54ed42cb0bade864629f11b8c7bc9bf9d4052a5e380983277"
+content-hash = "4d923a5f8f3d983acb05e909d590bf0a6117254b307d0b06bf8e2fac812e2e7f"
 python-versions = "^3.5"
 
 [metadata.hashes]
@@ -613,6 +624,7 @@ entrypoints = ["589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19
 fastcache = ["6de1b16e70335b7bde266707eb401a3aaec220fb66c5d13b02abf0eab8be782b"]
 fastdiff = ["623ad3d9055ab78e014d0d10767cb033d98d5d4f66052abf498350c8e42e29aa"]
 flake8 = ["19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548", "8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"]
+flake8-builtins = ["8d806360767947c0035feada4ddef3ede32f0a586ef457e62d811b8456ad9a51", "cd7b1b7fec4905386a3643b59f9ca8e305768da14a49a7efb31fe9364f33cd04"]
 flake8-comprehensions = ["35f826956e87f230415cde9c3b8b454e785736cf5ff0be551c441b41b937f699", "f0b61d983d608790abf3664830d68efd3412265c2d10f6a4ba1a353274dbeb64"]
 flake8-mutable = ["38fd9dadcbcda6550a916197bc40ed76908119dabb37fbcca30873666c31d2d5", "ee9b77111b867d845177bbc289d87d541445ffcc6029a0c5c65865b42b18c6a6"]
 flake8-print = ["5010e6c138b63b62400da4b06afa33becc5e08bd1fcce9af3752445cf3342f54"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ picamera = {version = "^1.13", extras=["array"], optional = true}
 bandit = "^1.6"
 chrono = "^1.0"
 flake8 = "^3.7"
+flake8-builtins = "^1.4"
 flake8-comprehensions = "^2.1"
 flake8-mutable = "^1.2"
 flake8-print = "^3.1"

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -32,7 +32,7 @@ def test_annotates_frame(filename, temp_image_file):
 @pytest.mark.parametrize("filename", IMAGE_DATA.keys())
 def test_gets_markers(filename, snapshot):
     class TestCamera(ImageFileCamera):
-        def get_marker_size(self, id):
+        def get_marker_size(self, marker_id):
             return 100
 
     camera = TestCamera(
@@ -59,7 +59,7 @@ def test_gets_markers(filename, snapshot):
 @pytest.mark.parametrize("filename,camera_name", IMAGE_DATA.items())
 def test_gets_markers_eager(filename, camera_name, snapshot):
     class TestCamera(ImageFileCamera):
-        def get_marker_size(self, id):
+        def get_marker_size(self, marker_id):
             return 100
 
     camera = TestCamera(
@@ -92,7 +92,7 @@ def test_gets_markers_eager(filename, camera_name, snapshot):
 @pytest.mark.parametrize("filename,camera_name", IMAGE_DATA.items())
 def test_gets_markers_with_calibration(filename, camera_name, snapshot):
     class TestCamera(ImageFileCamera):
-        def get_marker_size(self, id):
+        def get_marker_size(self, marker_id):
             return 100
 
     camera = TestCamera(

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -61,11 +61,13 @@ class BaseCamera:
             return [], []
         return [marker_id[0] for marker_id in marker_ids], [c[0] for c in corners]
 
-    def _get_marker(self, marker_id, corners, calibration_params):
-        return Marker(marker_id, corners, self.get_marker_size(id), calibration_params)
+    def _get_marker(self, marker_id: int, corners, calibration_params):
+        return Marker(
+            marker_id, corners, self.get_marker_size(marker_id), calibration_params
+        )
 
     def _get_eager_marker(
-        self, marker_id, corners, size, calibration_params, tvec, rvec
+        self, marker_id: int, corners, size: int, calibration_params, tvec, rvec
     ):
         return Marker(marker_id, corners, size, calibration_params, (rvec, tvec))
 
@@ -73,7 +75,7 @@ class BaseCamera:
         ids, corners = self._get_ids_and_corners(frame)
         calibration_params = self.get_calibrations()
         for corners, marker_id in zip(corners, ids):
-            yield self._get_marker(marker_id, corners, calibration_params)
+            yield self._get_marker(int(marker_id), corners, calibration_params)
 
     def process_frame_eager(self, *, frame=None):
         calibration_params = self.get_calibrations()
@@ -92,7 +94,7 @@ class BaseCamera:
             )
             for marker_id, corners, tvec, rvec in zip(ids, corners, tvecs, rvecs):
                 yield self._get_eager_marker(
-                    marker_id, corners, size, calibration_params, tvec[0], rvec[0]
+                    int(marker_id), corners, size, calibration_params, tvec[0], rvec[0]
                 )
 
     def get_visible_markers(self, *, frame=None):

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -56,22 +56,24 @@ class BaseCamera:
     def _get_ids_and_corners(self, frame=None):
         if frame is None:
             frame = self.capture_frame()
-        ids, corners = self._get_raw_ids_and_corners(frame)
-        if ids is None:
+        marker_ids, corners = self._get_raw_ids_and_corners(frame)
+        if marker_ids is None:
             return [], []
-        return [id[0] for id in ids], [c[0] for c in corners]
+        return [marker_id[0] for marker_id in marker_ids], [c[0] for c in corners]
 
-    def _get_marker(self, id, corners, calibration_params):
-        return Marker(id, corners, self.get_marker_size(id), calibration_params)
+    def _get_marker(self, marker_id, corners, calibration_params):
+        return Marker(marker_id, corners, self.get_marker_size(id), calibration_params)
 
-    def _get_eager_marker(self, id, corners, size, calibration_params, tvec, rvec):
-        return Marker(id, corners, size, calibration_params, (rvec, tvec))
+    def _get_eager_marker(
+        self, marker_id, corners, size, calibration_params, tvec, rvec
+    ):
+        return Marker(marker_id, corners, size, calibration_params, (rvec, tvec))
 
     def process_frame(self, *, frame=None):
         ids, corners = self._get_ids_and_corners(frame)
         calibration_params = self.get_calibrations()
-        for corners, id in zip(corners, ids):
-            yield self._get_marker(id, corners, calibration_params)
+        for corners, marker_id in zip(corners, ids):
+            yield self._get_marker(marker_id, corners, calibration_params)
 
     def process_frame_eager(self, *, frame=None):
         calibration_params = self.get_calibrations()
@@ -88,9 +90,9 @@ class BaseCamera:
             rvecs, tvecs, _ = cv2.aruco.estimatePoseSingleMarkers(
                 corners, size, *calibration_params
             )
-            for id, corners, tvec, rvec in zip(ids, corners, tvecs, rvecs):
+            for marker_id, corners, tvec, rvec in zip(ids, corners, tvecs, rvecs):
                 yield self._get_eager_marker(
-                    id, corners, size, calibration_params, tvec[0], rvec[0]
+                    marker_id, corners, size, calibration_params, tvec[0], rvec[0]
                 )
 
     def get_visible_markers(self, *, frame=None):
@@ -103,7 +105,7 @@ class BaseCamera:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, *args):
         self.close()
 
     def __del__(self):

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -13,19 +13,19 @@ from .exceptions import MissingCalibrationsError
 class Marker:
     def __init__(
         self,
-        id,
+        marker_id,
         corners,
         size: int,
         calibration_params: Optional[CalibrationParameters] = None,
         precalculated_vectors=None,
     ):
-        self.__id = int(id)
+        self.__id = int(marker_id)
         self.__pixel_corners = corners
         self.__size = size
         self.__camera_calibration_params = calibration_params
         self.__precalculated_vectors = precalculated_vectors
 
-    @property
+    @property  # noqa: A003
     def id(self):
         return self.__id
 

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -13,13 +13,13 @@ from .exceptions import MissingCalibrationsError
 class Marker:
     def __init__(
         self,
-        marker_id,
+        marker_id: int,
         corners,
         size: int,
         calibration_params: Optional[CalibrationParameters] = None,
         precalculated_vectors=None,
     ):
-        self.__id = int(marker_id)
+        self.__id = marker_id
         self.__pixel_corners = corners
         self.__size = size
         self.__camera_calibration_params = calibration_params
@@ -34,7 +34,7 @@ class Marker:
         return self.__size
 
     def _is_eager(self):
-        return bool(self.__precalculated_vectors)
+        return self.__precalculated_vectors is not None
 
     @property
     def pixel_corners(self):


### PR DESCRIPTION
Stop shadowing builtin variables, to keep things somewhat cleaner.

I've intentionally ignored `marker.id`, as that's obvious from context what it is, and `marker.marker_id` kinda looks horrible!

I also took the time to fix unnecessarily casting the marker's id to an `int`, just to again tidy things up.