### PR TITLE
Fix image buffer caching captured images for too long

### DIFF
--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -1,4 +1,4 @@
-from cv2 import VideoCapture, CAP_PROP_BUFFERSIZE
+from cv2 import CAP_PROP_BUFFERSIZE, VideoCapture
 
 from .base import BaseCamera
 

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -14,6 +14,8 @@ class Camera(BaseCamera):
         return cap
 
     def capture_frame(self):
+        # Hack: Double capture frames to fill buffer.
+        _, _ = self.video_capture.read()
         _, frame = self.video_capture.read()
         return frame
 

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -10,12 +10,12 @@ class Camera(BaseCamera):
 
     def get_video_capture(self, camera_id):
         cap = VideoCapture(camera_id)
-        cap.set(CAP_PROP_BUFFERSIZE)
+        cap.set(CAP_PROP_BUFFERSIZE, 1)
         return cap
 
     def capture_frame(self):
         # Hack: Double capture frames to fill buffer.
-        _, _ = self.video_capture.read()
+        self.video_capture.read()
         _, frame = self.video_capture.read()
         return frame
 

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -1,4 +1,4 @@
-from cv2 import VideoCapture
+from cv2 import VideoCapture, CAP_PROP_BUFFERSIZE
 
 from .base import BaseCamera
 
@@ -9,7 +9,9 @@ class Camera(BaseCamera):
         self.video_capture = self.get_video_capture(camera_id)
 
     def get_video_capture(self, camera_id):
-        return VideoCapture(camera_id)
+        cap = VideoCapture(camera_id)
+        cap.set(CAP_PROP_BUFFERSIZE)
+        return cap
 
     def capture_frame(self):
         _, frame = self.video_capture.read()


### PR DESCRIPTION
Fixes #94 

- Set `CAP_PROP_BUFFERSIZE` to `1` (Minimum value).
- Double capture to fill the buffer of 1 that is remaining.