### PR TITLE
Define dependencies in `setup.py` rather than `requirements.txt`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,3 @@
--r requirements.txt
-
 bandit==1.6.2
 chrono==1.0.2
 flake8==3.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-opencv-contrib-python-headless>=4.0,<4.1
-cached-property>=1.5
-coordinates>=0.3.0
-fastcache>=1.1
-ujson>=1.35

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ from setuptools import find_packages, setup
 with open("README.md") as f:
     readme = f.read()
 
-with open("requirements.txt") as f:
-    requirements = f.read().split("\n")
-
 setup(
     name="zoloto",
     version="0.4.0",

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
         "cached-property>=1.5",
         "coordinates>=0.3.0",
         "fastcache>=1.1",
-        "ujson>=1.35"
-
+        "ujson>=1.35",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,14 @@ setup(
     long_description_content_type="text/markdown",
     license="BSD",
     packages=find_packages(include="zoloto*"),
-    install_requires=requirements,
+    install_requires=[
+        "opencv-contrib-python-headless>=4.0,<4.1",
+        "cached-property>=1.5",
+        "coordinates>=0.3.0",
+        "fastcache>=1.1",
+        "ujson>=1.35"
+
+    ],
     entry_points={
         "console_scripts": [
             "zoloto-preview=zoloto.cli.preview:main",


### PR DESCRIPTION
I've definitely defined them like this before, but moving into setup.py is just easier and simpler.

Fixes #115 