### PR TITLE
Enumerate cameras

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,3 +15,4 @@ pytest-cov==2.8.1
 isort==4.3.21
 black==19.10b0; python_version >= '3.6'
 snapshottest==0.5.1
+pytest-mock==2.0.0

--- a/tests/test_camera/test_camera_module.py
+++ b/tests/test_camera/test_camera_module.py
@@ -1,6 +1,7 @@
 import pytest
 
 import zoloto.cameras
+from zoloto.marker_dict import MarkerDict
 
 
 def test_exposes_camera():
@@ -12,3 +13,43 @@ def test_exposes_file_camera(camera_name):
     assert getattr(zoloto.cameras, camera_name) == getattr(
         zoloto.cameras.file, camera_name
     )
+
+
+@pytest.mark.parametrize(
+    "camera_class", [zoloto.cameras.Camera, zoloto.cameras.camera.SnapshotCamera]
+)
+def test_enumerate_all_cameras(camera_class, mocker):
+    VideoCapture = mocker.patch("zoloto.cameras.camera.VideoCapture")
+    VideoCapture.return_value.isOpened.return_value = True
+    discovered_cameras = list(
+        camera_class.discover(marker_dict=MarkerDict.DICT_4X4_100)
+    )
+    assert len(discovered_cameras) == 8
+    for camera in discovered_cameras:
+        assert isinstance(camera, camera_class)
+
+
+@pytest.mark.parametrize(
+    "camera_class", [zoloto.cameras.Camera, zoloto.cameras.camera.SnapshotCamera]
+)
+def test_enumerate_no_cameras(camera_class, mocker):
+    VideoCapture = mocker.patch("zoloto.cameras.camera.VideoCapture")
+    VideoCapture.return_value.isOpened.return_value = False
+    discovered_cameras = list(
+        camera_class.discover(marker_dict=MarkerDict.DICT_4X4_100)
+    )
+    assert len(discovered_cameras) == 0
+
+
+def test_get_camera_ids(mocker):
+    VideoCapture = mocker.patch("zoloto.cameras.camera.VideoCapture")
+    VideoCapture.return_value.isOpened.return_value = True
+    discovered_ids = list(zoloto.cameras.camera.find_camera_ids())
+    assert discovered_ids == [0, 1, 2, 3, 4, 5, 6, 7]
+
+
+def test_get_no_camera_ids(mocker):
+    VideoCapture = mocker.patch("zoloto.cameras.camera.VideoCapture")
+    VideoCapture.return_value.isOpened.return_value = False
+    discovered_ids = list(zoloto.cameras.camera.find_camera_ids())
+    assert len(discovered_ids) == 0

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -25,6 +25,7 @@ class Camera(BaseCamera):
 
     def get_video_capture(self, camera_id):
         cap = VideoCapture(camera_id)
+        assert cap.isOpened()
         cap.set(CAP_PROP_BUFFERSIZE, 1)
         return cap
 

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -3,10 +3,25 @@ from cv2 import CAP_PROP_BUFFERSIZE, VideoCapture
 from .base import BaseCamera
 
 
+def find_camera_ids():
+    """
+    Find and return ids of connected cameras.
+
+    Works the same as VideoCapture(-1).
+    """
+    for camera_id in range(8):
+        capture = VideoCapture(camera_id)
+        opened = capture.isOpened()
+        capture.release()
+        if opened:
+            yield camera_id
+
+
 class Camera(BaseCamera):
     def __init__(self, camera_id: int, **kwargs):
         super().__init__(**kwargs)
-        self.video_capture = self.get_video_capture(camera_id)
+        self.camera_id = camera_id
+        self.video_capture = self.get_video_capture(self.camera_id)
 
     def get_video_capture(self, camera_id):
         cap = VideoCapture(camera_id)
@@ -22,6 +37,11 @@ class Camera(BaseCamera):
     def close(self):
         super().close()
         self.video_capture.release()
+
+    @classmethod
+    def discover(cls, **kwargs):
+        for camera_id in find_camera_ids():
+            yield cls(camera_id, **kwargs)
 
 
 class SnapshotCamera(BaseCamera):
@@ -43,3 +63,8 @@ class SnapshotCamera(BaseCamera):
         _, frame = video_capture.read()
         video_capture.release()
         return frame
+
+    @classmethod
+    def discover(cls, **kwargs):
+        for camera_id in find_camera_ids():
+            yield cls(camera_id, **kwargs)

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -25,7 +25,6 @@ class Camera(BaseCamera):
 
     def get_video_capture(self, camera_id):
         cap = VideoCapture(camera_id)
-        assert cap.isOpened()
         cap.set(CAP_PROP_BUFFERSIZE, 1)
         return cap
 


### PR DESCRIPTION
Fixes #33 

Allow enumeration of cameras. Currently only tested on Linux, but should theoretically work everywhere else.

This currently forcefully outputs text for each camera, which is annoying. This can be fixed once https://github.com/opencv/opencv/pull/15111 merges.