### PR TITLE
Replace `fastcache` with `functools.lru_cache`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         "opencv-contrib-python-headless>=4.0,<4.1",
         "cached-property>=1.5",
         "coordinates>=0.3.0",
-        "fastcache>=1.1",
         "ujson>=1.35",
     ],
     entry_points={

--- a/zoloto/calibration.py
+++ b/zoloto/calibration.py
@@ -1,9 +1,9 @@
 import json
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
 
 from cv2 import FILE_STORAGE_READ, FILE_STORAGE_WRITE, FileStorage, aruco
-from fastcache import clru_cache
 from numpy import array
 
 from .marker_dict import MarkerDict
@@ -16,7 +16,7 @@ CalibrationParameters = NamedTuple(
 SUPPORTED_EXTENSIONS = ["xml", "json"]
 
 
-@clru_cache()
+@lru_cache()
 def parse_calibration_file(calibration_file: Path) -> CalibrationParameters:
     if not calibration_file.exists():
         raise FileNotFoundError(calibration_file)
@@ -51,7 +51,7 @@ def save_calibrations(params: CalibrationParameters, filename: Path):
         raise ValueError("Unknown calibration file format: " + file_extension)
 
 
-@clru_cache()
+@lru_cache()
 def get_fake_calibration_parameters(
     size: int, iterations: int = 15
 ) -> CalibrationParameters:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -1,8 +1,8 @@
+from functools import lru_cache
 from typing import Optional
 
 from cached_property import cached_property
 from cv2 import aruco
-from fastcache import clru_cache
 from numpy import arctan2, array, linalg
 
 from .calibration import CalibrationParameters
@@ -62,7 +62,7 @@ class Marker:
     def cartesian(self):
         return ThreeDCoordinates(*self._tvec)
 
-    @clru_cache(maxsize=None)
+    @lru_cache(maxsize=None)
     def _get_pose_vectors(self):
         if self._is_eager():
             return self.__precalculated_vectors


### PR DESCRIPTION
Fixes #131 

`functools.lru_cache` is already implemented in C in >=3.5, and better optimised.

https://github.com/pbrady/fastcache#performance-warning