### PR TITLE
Include py.typed in dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     license="BSD",
     packages=find_packages(include="zoloto*"),
+    package_data={"zoloto": ["py.typed"]},
     install_requires=[
         "opencv-contrib-python-headless>=4.0,<4.1",
         "cached-property>=1.5",


### PR DESCRIPTION
Currently is not included in packages on PyPI due to this.

See https://github.com/sedders123/phial/blob/91159974a4399d3a28aa8eaa49032eb3cee53d89/setup.py#L50 for reference.

A release will need to be made to fix the 0.5.1 packages on PyPI. As it's a packaging error, I'd suggest a postrelease.