### PR TITLE
Fix identify marker example

### DIFF
--- a/examples/identify-markers.py
+++ b/examples/identify-markers.py
@@ -2,12 +2,12 @@ import sys
 from pathlib import Path
 
 from zoloto.cameras.file import VideoFileCamera
-from zoloto.marker_dict import MarkerDict
+from zoloto.marker_type import MarkerType
 
 
-def process_marker_dict(current_marker_dict: MarkerDict) -> None:
+def process_marker_type(current_marker_type: MarkerType) -> None:
     class TestCamera(VideoFileCamera):
-        marker_dict = current_marker_dict
+        marker_type = current_marker_type
 
         def get_marker_size(self, marker_id: int) -> int:
             return 100
@@ -15,17 +15,17 @@ def process_marker_dict(current_marker_dict: MarkerDict) -> None:
     found_markers = False
     with TestCamera(Path(sys.argv[1])) as camera:
         for i, frame in enumerate(camera):
-            print(current_marker_dict, i, end="\r")  # noqa: T001
+            print(current_marker_type, i, end="\r")  # noqa: T001
             if i % 3 == 0:
                 if camera.get_visible_markers(frame=frame):
                     found_markers = True
 
-    print(current_marker_dict, found_markers)  # noqa: T001
+    print(current_marker_type, found_markers)  # noqa: T001
 
 
 def main() -> None:
-    for marker_dict in MarkerDict:
-        process_marker_dict(marker_dict)
+    for marker_type in MarkerType:
+        process_marker_type(marker_type)
 
 
 if __name__ == "__main__":

--- a/examples/identify-markers.py
+++ b/examples/identify-markers.py
@@ -19,6 +19,7 @@ def process_marker_type(current_marker_type: MarkerType) -> None:
             if i % 3 == 0:
                 if camera.get_visible_markers(frame=frame):
                     found_markers = True
+                    break
 
     print(current_marker_type, found_markers)  # noqa: T001
 


### PR DESCRIPTION
Fixes a bad merge where the `identify-markers` example wasn't modified as part of #154 

This is also why tests on `master` are failing