### PR TITLE
Prevent passing arguments to cached method

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,8 @@ class CachedMethodTestCase(TestCase):
         self.counter = 0
 
     @cached_method
-    def increment(self, by: int = 1) -> None:
-        self.counter += by
+    def increment(self) -> None:
+        self.counter += 1
 
     def test_caches(self) -> None:
         self.assertEqual(self.counter, 0)
@@ -17,13 +17,6 @@ class CachedMethodTestCase(TestCase):
         self.assertEqual(self.counter, 1)
         self.increment()
         self.assertEqual(self.counter, 1)
-
-    def test_passes_args(self) -> None:
-        self.assertEqual(self.counter, 0)
-        self.increment(2)
-        self.assertEqual(self.counter, 2)
-        self.increment(2)
-        self.assertEqual(self.counter, 2)
 
 
 def test_encode_as_json() -> None:

--- a/zoloto/utils.py
+++ b/zoloto/utils.py
@@ -2,7 +2,7 @@ import json
 from functools import wraps
 from typing import Any, Callable, TypeVar
 
-T = TypeVar("T", bound=Callable)
+T = TypeVar("T", bound=Callable[[Any], Any])
 
 
 def cached_method(f: T) -> T:
@@ -12,9 +12,9 @@ def cached_method(f: T) -> T:
     """
 
     @wraps(f)
-    def wrapper(obj: Any, *args: Any, **kwargs: Any) -> None:
-        value = f(obj, *args, **kwargs)
-        obj.__dict__[f.__name__] = lambda *args, **kwargs: value
+    def wrapper(obj: Any) -> Any:
+        value = f(obj)
+        obj.__dict__[f.__name__] = lambda: value
         return value
 
     wrapper.__wrapped__ = f  # type: ignore


### PR DESCRIPTION
The argument isn't considered as part of the cache key, which is unsafe. So just remove it.

Also tighten up the types to reflect this.