### PR TITLE
Use VideoCaptureMixin as capture_frame implementation

### DIFF
--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -22,7 +22,7 @@ def find_camera_ids() -> Generator[int, None, None]:
             yield camera_id
 
 
-class Camera(BaseCamera, IterableCameraMixin, VideoCaptureMixin):
+class Camera(VideoCaptureMixin, IterableCameraMixin, BaseCamera):
     def __init__(
         self, camera_id: int, *, calibration_file: Optional[Path] = None
     ) -> None:
@@ -50,7 +50,7 @@ class Camera(BaseCamera, IterableCameraMixin, VideoCaptureMixin):
             yield cls(camera_id, **kwargs)
 
 
-class SnapshotCamera(BaseCamera, VideoCaptureMixin):
+class SnapshotCamera(VideoCaptureMixin, BaseCamera):
     """
     A modified version of Camera optimised for single use.
 

--- a/zoloto/cameras/file.py
+++ b/zoloto/cameras/file.py
@@ -21,7 +21,7 @@ class ImageFileCamera(BaseCamera):
         return imread(str(self.image_path))
 
 
-class VideoFileCamera(VideoCaptureMixin, BaseCamera, IterableCameraMixin):
+class VideoFileCamera(VideoCaptureMixin, IterableCameraMixin, BaseCamera):
     def __init__(
         self, video_path: Path, *, calibration_file: Optional[Path] = None
     ) -> None:

--- a/zoloto/cameras/rpi.py
+++ b/zoloto/cameras/rpi.py
@@ -10,7 +10,7 @@ from .base import BaseCamera
 from .mixins import IterableCameraMixin
 
 
-class PiCamera(BaseCamera, IterableCameraMixin):
+class PiCamera(IterableCameraMixin, BaseCamera):
     def __init__(self, *, calibration_file: Optional[Path] = None) -> None:
         super().__init__(calibration_file=calibration_file)
         self.camera = picamera.PiCamera()


### PR DESCRIPTION
When the inheritance of classes is in any other order for `Camera`, it
results in the abstract `capture_frame` implementation being used
instead of the implementation in `VideoCaptureMixin`. This results in
`NotImplementedError`s whenever using either of these cameras.
Interestingly, this is not caught by linting, typing or the runtime
protections against executing `abstractmethod`s.

Code to reproduce bug before this patch:

```python
from zoloto.cameras import Camera
from zoloto.marker_type import MarkerType

class ZolotoCamera(Camera):

    marker_type = MarkerType.DICT_APRILTAG_36H11

    def get_marker_size(self, marker_id: int) -> int:
        return 80

cam = ZolotoCamera(0)

cam.capture_frame()
```

Possible inheritance orders:

- `class Camera(BaseCamera, IterableCameraMixin, VideoCaptureMixin):` - Nope
- `class Camera(IterableCameraMixin, VideoCaptureMixin, BaseCamera):` - Nope, idk why
- `class Camera(VideoCaptureMixin, IterableCameraMixin, BaseCamera):` - Yes