### PR TITLE
Drop 3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.5, 3.6, 3.7]
+        python: [3.6, 3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 bandit>=1<2
 chrono>=1<2
 flake8>=3.8<4
-flake8-bugbear>=19<21
+flake8-bugbear>=20<21
 flake8-builtins>=1<2
 flake8-comprehensions>=3<4
 flake8-mutable>=1<2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Issues": "https://github.com/RealOrangeOne/zoloto/issues",
     },
     entry_points={"console_scripts": ["zoloto-preview=zoloto.cli.preview:main"]},
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require={"rpi": ["picamera[array]>=1.13"], "viewer": ["Pillow>=7.0.0"]},
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -35,7 +35,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Fixes #205 

Python 3.5 went EoL on 13th September 2020. We don't need to maintain support for it anymore.

I look forward to all the nice typehinting we can do now!