### PR TITLE
Fix marker pdf sizes

### DIFF
--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -43,7 +43,7 @@ def main(args: argparse.Namespace) -> None:
 
     if args.force_a4 and page_size == PageSize.A4:
         # NOTE: This also currently only supports A3 (halving the image)
-        print("--force-a4 doesn't make sense with a page size of A4")
+        print("--force-a4 doesn't make sense with a page size of A4")  # noqa:T001
 
     output_dir: Path = args.path.resolve()
     output_dir.mkdir(exist_ok=True, parents=True)
@@ -53,14 +53,13 @@ def main(args: argparse.Namespace) -> None:
     required_size = args.size + (pixel_size * 2)
 
     if args.size + BORDER_SIZE * 2 > min(page_size.value):
-        print(
+        print(  # noqa:T001
             f"Warning: Marker size is too large to fit on {args.page_size}"
-        )  # noqa:T001
-
+        )
     elif required_size + BORDER_SIZE * 2 > min(page_size.value):
-        print(
+        print(  # noqa:T001
             f"Warning: Marker size is too large to fit on {args.page_size} with border"
-        )  # noqa:T001
+        )
 
     marker_ids = (
         parse_ranges(args.range) if args.range != "ALL" else range(marker_type.max_id)

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -1,4 +1,5 @@
 import argparse
+from enum import Enum
 from pathlib import Path
 
 from zoloto.cameras.marker import MarkerCamera
@@ -22,18 +23,39 @@ def mm_to_pixels(mm: int) -> int:
     return int(mm_to_inches(mm) * DPI)
 
 
-A4 = (mm_to_pixels(210), mm_to_pixels(297))
+class PageSize(Enum):
+    A3 = (297, 420)
+    A4 = (210, 297)
+
+    @property
+    def pixels(self):
+        return (
+            mm_to_pixels(self.value[0]),
+            mm_to_pixels(self.value[1]),
+        )
 
 
 def main(args: argparse.Namespace) -> None:
     from PIL import Image, ImageOps, ImageDraw
 
     marker_type = MarkerType[args.type]
+    page_size = PageSize[args.page_size]
     output_dir: Path = args.path.resolve()
     output_dir.mkdir(exist_ok=True, parents=True)
 
-    if args.size + BORDER_SIZE * 2 > 210:
-        print("Warning: Marker size is too large to fit on A4")  # noqa:T001
+    # Captured frame includes white padding, so image size needs to be scaled to account
+    pixel_size = args.size // marker_type.min_marker_image_size
+    required_size = args.size + (pixel_size * 2)
+
+    if args.size + BORDER_SIZE * 2 > min(page_size.value):
+        print(
+            f"Warning: Marker size is too large to fit on {args.page_size}"
+        )  # noqa:T001
+
+    elif required_size + BORDER_SIZE * 2 > min(page_size.value):
+        print(
+            f"Warning: Marker size is too large to fit on {args.page_size} with border"
+        )  # noqa:T001
 
     marker_ids = (
         parse_ranges(args.range) if args.range != "ALL" else range(marker_type.max_id)
@@ -49,7 +71,7 @@ def main(args: argparse.Namespace) -> None:
             image = Image.fromarray(camera.capture_frame())
 
             # Resize the image to the required size
-            resized_image = image.resize([mm_to_pixels(args.size)] * 2, resample=0)
+            resized_image = image.resize([mm_to_pixels(required_size)] * 2, resample=0)
 
             # Add a border to the marker, which includes padding
             bordered_image = ImageOps.expand(
@@ -65,14 +87,18 @@ def main(args: argparse.Namespace) -> None:
                 anchor="lt",
             )
 
-            # Put marker onto A4 page
-            a4_img = Image.new("RGB", A4, (255, 255, 255))
-            a4_img.paste(
-                bordered_image, ((A4[0] - img_size) // 2, (A4[1] - img_size) // 2)
+            # Put marker onto page
+            paper_img = Image.new("RGB", page_size.pixels, (255, 255, 255))
+            paper_img.paste(
+                bordered_image,
+                (
+                    (page_size.pixels[0] - img_size) // 2,
+                    (page_size.pixels[1] - img_size) // 2,
+                ),
             )
 
             print("Saving", marker_id)  # noqa:T001
-            a4_img.save(
+            paper_img.save(
                 output_dir / "{}.pdf".format(marker_id),
                 "PDF",
                 quality=100,
@@ -82,7 +108,7 @@ def main(args: argparse.Namespace) -> None:
 
 def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser(
-        "marker-pdfs", description="Output A4 PDFs for all marker images"
+        "marker-pdfs", description="Output PDFs for all marker images"
     )
     parser.add_argument(
         "type",
@@ -110,5 +136,12 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--range",
         help="Marker ids to output (inclusive)",
         default="ALL",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=str,
+        help="Page size. (default: %(default)s)",
+        choices=sorted([size.name for size in PageSize]),
+        default="A4",
     )
     parser.set_defaults(func=main)

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -1,6 +1,7 @@
 import argparse
 from enum import Enum
 from pathlib import Path
+from typing import Tuple
 
 from zoloto.cameras.marker import MarkerCamera
 from zoloto.marker_type import MARKER_TYPE_NAMES, MarkerType
@@ -28,7 +29,7 @@ class PageSize(Enum):
     A4 = (210, 297)
 
     @property
-    def pixels(self):
+    def pixels(self) -> Tuple[int, int]:
         return (
             mm_to_pixels(self.value[0]),
             mm_to_pixels(self.value[1]),


### PR DESCRIPTION
Previously, the marker sizes in the PDFs accounted for the white padding around the markers themselves. This is incorrect, and lead to poorly sized images, and incorrect calculations.

This PR corrects those sizes, along with allowing output on A3, and A3 sized markers split over A4 pages.

Example split PDF: [0.pdf](https://github.com/RealOrangeOne/zoloto/files/7833699/0.pdf)
 