### PR TITLE
Upgrade syntax

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from tests.conftest import *  # noqa

--- a/benchmarks/test_marker.py
+++ b/benchmarks/test_marker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable
 

--- a/benchmarks/test_marker_camera.py
+++ b/benchmarks/test_marker_camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Callable
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import zoloto
 
 project = "Zoloto"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ extensions = [
     "m2r2",
 ]
 
-templates_path = []  # type: List[str]
+templates_path: List[str] = []
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
@@ -30,7 +30,7 @@ intersphinx_mapping = {
 
 html_theme = "sphinx_rtd_theme"
 
-html_static_path = []  # type: List[str]
+html_static_path: List[str] = []
 
 autodoc_default_options = {
     "member-order": "alphabetical",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ extensions = [
     "m2r2",
 ]
 
-templates_path: List[str] = []
+templates_path: list[str] = []
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
@@ -32,7 +32,7 @@ intersphinx_mapping = {
 
 html_theme = "sphinx_rtd_theme"
 
-html_static_path: List[str] = []
+html_static_path: list[str] = []
 
 autodoc_default_options = {
     "member-order": "alphabetical",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 import zoloto

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from tempfile import mkstemp

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 
 from hypothesis import strategies

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_camera/test_camera.py
+++ b/tests/test_camera/test_camera.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import warnings
 from itertools import cycle
 from pathlib import Path
-from typing import Type
 
 import pytest
 from cv2 import CAP_PROP_FRAME_HEIGHT, CAP_PROP_FRAME_WIDTH

--- a/tests/test_camera/test_camera.py
+++ b/tests/test_camera/test_camera.py
@@ -21,7 +21,7 @@ from zoloto.marker_type import MarkerType
 )
 @given(marker_types())
 def test_enumerate_all_cameras(
-    camera_class: Type[zoloto.cameras.Camera],
+    camera_class: type[zoloto.cameras.Camera],
     mocker: MockerFixture,
     marker_type: MarkerType,
 ) -> None:
@@ -40,7 +40,7 @@ def test_enumerate_all_cameras(
 )
 @given(marker_types())
 def test_enumerate_no_cameras(
-    camera_class: Type[zoloto.cameras.Camera],
+    camera_class: type[zoloto.cameras.Camera],
     mocker: MockerFixture,
     marker_type: MarkerType,
 ) -> None:

--- a/tests/test_camera/test_camera.py
+++ b/tests/test_camera/test_camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from itertools import cycle
 from pathlib import Path

--- a/tests/test_camera/test_camera_module.py
+++ b/tests/test_camera/test_camera_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_camera/test_marker_camera.py
+++ b/tests/test_camera/test_marker_camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from typing import List
 
 
 def call_cli(args: list[str]) -> subprocess.CompletedProcess:

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 from typing import List

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -5,10 +5,9 @@ import sys
 from typing import List
 
 
-def call_cli(args: List[str]) -> subprocess.CompletedProcess:
+def call_cli(args: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, "-m", "zoloto"] + args,
-        universal_newlines=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        text=True,
+        capture_output=True,
     )

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 
 import zoloto

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from zoloto.marker_type import MarkerType

--- a/tests/test_cli/test_save_markers.py
+++ b/tests/test_cli/test_save_markers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from zoloto.marker_type import MarkerType

--- a/tests/test_cli/test_validate_calibration.py
+++ b/tests/test_cli/test_validate_calibration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Callable
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,8 +1,6 @@
 """Tests for coordinates classes."""
 from __future__ import annotations
 
-from typing import Tuple
-
 from hypothesis import given
 from hypothesis.strategies import floats, tuples
 from pyquaternion import Quaternion

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,4 +1,6 @@
 """Tests for coordinates classes."""
+from __future__ import annotations
+
 from typing import Tuple
 
 from hypothesis import given

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -11,7 +11,7 @@ from zoloto.coords import Orientation
 
 
 @given(tuples(floats(), floats(), floats()))
-def test_valid_conversion(euler_angles: Tuple[float, float, float]) -> None:
+def test_valid_conversion(euler_angles: tuple[float, float, float]) -> None:
     """
     Test conversion from the vector.
 
@@ -26,7 +26,7 @@ def test_valid_conversion(euler_angles: Tuple[float, float, float]) -> None:
 
 
 @given(tuples(floats(), floats(), floats()))
-def test_rot_yaw_pitch_roll(euler_angles: Tuple[float, float, float]) -> None:
+def test_rot_yaw_pitch_roll(euler_angles: tuple[float, float, float]) -> None:
     """Test that x,y,z are equal to yaw, pitch, roll."""
     q = Quaternion(axis=euler_angles, scalar=1)
     orientation = Orientation(*q.vector)
@@ -37,7 +37,7 @@ def test_rot_yaw_pitch_roll(euler_angles: Tuple[float, float, float]) -> None:
 
 
 @given(tuples(floats(), floats(), floats()))
-def test_iterator(euler_angles: Tuple[float, float, float]) -> None:
+def test_iterator(euler_angles: tuple[float, float, float]) -> None:
     """Test that the iterator returns the correct values."""
     q = Quaternion(axis=euler_angles, scalar=1)
     orientation = Orientation(*q.vector)
@@ -52,7 +52,7 @@ def test_iterator(euler_angles: Tuple[float, float, float]) -> None:
 
 
 @given(tuples(floats(), floats(), floats()))
-def test_repr(euler_angles: Tuple[float, float, float]) -> None:
+def test_repr(euler_angles: tuple[float, float, float]) -> None:
     """Test that the representation is as expected."""
     q = Quaternion(axis=euler_angles, scalar=1)
     orientation = Orientation(*q.vector)
@@ -63,4 +63,4 @@ def test_repr(euler_angles: Tuple[float, float, float]) -> None:
     repr_str = repr(orientation)
 
     for name, val in zip(names, ypr):
-        assert "{}={}".format(name, val) in repr_str
+        assert f"{name}={val}" in repr_str

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -22,7 +22,7 @@ class MarkerTestCase(TestCase):
             marker_size=self.MARKER_SIZE,
             marker_type=MarkerType.ARUCO_6X6,
         )
-        self.markers: List[BaseMarker] = list(
+        self.markers: list[BaseMarker] = list(
             self.marker_camera.process_frame()
         )
         self.marker = self.markers[0]

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from typing import Any, List
 from unittest import TestCase

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -22,9 +22,7 @@ class MarkerTestCase(TestCase):
             marker_size=self.MARKER_SIZE,
             marker_type=MarkerType.ARUCO_6X6,
         )
-        self.markers: list[BaseMarker] = list(
-            self.marker_camera.process_frame()
-        )
+        self.markers: list[BaseMarker] = list(self.marker_camera.process_frame())
         self.marker = self.markers[0]
 
     def assertIsType(self, a: Any, b: Any) -> None:

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -20,9 +20,9 @@ class MarkerTestCase(TestCase):
             marker_size=self.MARKER_SIZE,
             marker_type=MarkerType.ARUCO_6X6,
         )
-        self.markers = list(
+        self.markers: List[BaseMarker] = list(
             self.marker_camera.process_frame()
-        )  # type: List[BaseMarker]
+        )
         self.marker = self.markers[0]
 
     def assertIsType(self, a: Any, b: Any) -> None:

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, List
+from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/tests/test_marker_type.py
+++ b/tests/test_marker_type.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import cv2
 import pytest
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from setuptools.config import read_configuration
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import TestCase
 
 import pytest

--- a/zoloto/__init__.py
+++ b/zoloto/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from zoloto.coords import Coordinates, Orientation, Spherical, ThreeDCoordinates
 from zoloto.marker import Marker
 from zoloto.marker_type import MarkerType

--- a/zoloto/__main__.py
+++ b/zoloto/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from zoloto.cli import main
 
 if __name__ == "__main__":

--- a/zoloto/calibration.py
+++ b/zoloto/calibration.py
@@ -14,7 +14,7 @@ from .marker_type import MarkerType
 class CalibrationParameters(NamedTuple):
     camera_matrix: NDArray[floating]
     distance_coefficients: NDArray[floating]
-    resolution: Tuple[int, int]
+    resolution: tuple[int, int]
 
 
 def parse_calibration_file(calibration_file: Path) -> CalibrationParameters:
@@ -34,7 +34,7 @@ def parse_calibration_file(calibration_file: Path) -> CalibrationParameters:
     return params
 
 
-@lru_cache()
+@lru_cache
 def get_fake_calibration_parameters() -> CalibrationParameters:
     """
     HACK: Generate fake calibration parameters

--- a/zoloto/calibration.py
+++ b/zoloto/calibration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Tuple

--- a/zoloto/calibration.py
+++ b/zoloto/calibration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import NamedTuple, Tuple
+from typing import NamedTuple
 
 from cv2 import FILE_STORAGE_READ, FileStorage, aruco
 from numpy import floating

--- a/zoloto/cameras/__init__.py
+++ b/zoloto/cameras/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from zoloto.cameras.camera import Camera
 from zoloto.cameras.file import ImageFileCamera, VideoFileCamera
 

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from itertools import groupby
 from pathlib import Path
-from typing import Any, Generator, List, Optional, Tuple, TypeVar, Union, cast
+from typing import Any, Generator, TypeVar, cast
 
 import cv2
 from numpy.typing import NDArray

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from itertools import groupby
 from pathlib import Path

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -22,7 +22,7 @@ class BaseCamera(ABC):
         *,
         marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Path | None = None
+        calibration_file: Path | None = None,
     ) -> None:
         self.marker_type = marker_type
         self.marker_dictionary = cv2.aruco.getPredefinedDictionary(self.marker_type)

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Generator, Optional, Tuple
+from typing import Any, Generator
 
 from cv2 import CAP_PROP_BUFFERSIZE, VideoCapture
 from numpy.typing import NDArray

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -36,10 +36,10 @@ class Camera(VideoCaptureMixin, IterableCameraMixin, BaseCamera, ViewableCameraM
         self,
         camera_id: int,
         *,
-        marker_size: Optional[int] = None,
+        marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Optional[Path] = None,
-        resolution: Optional[Tuple[int, int]] = None,
+        calibration_file: Path | None = None,
+        resolution: tuple[int, int] | None = None,
     ) -> None:
         super().__init__(
             marker_size=marker_size,
@@ -67,10 +67,10 @@ class Camera(VideoCaptureMixin, IterableCameraMixin, BaseCamera, ViewableCameraM
         cap.set(CAP_PROP_BUFFERSIZE, 1)
         return cap
 
-    def _set_resolution(self, resolution: Tuple[int, int]) -> None:
+    def _set_resolution(self, resolution: tuple[int, int]) -> None:
         set_video_capture_resolution(self.video_capture, resolution)
 
-    def get_resolution(self) -> Tuple[int, int]:
+    def get_resolution(self) -> tuple[int, int]:
         return get_video_capture_resolution(self.video_capture)
 
     def capture_frame(self) -> NDArray:
@@ -83,7 +83,7 @@ class Camera(VideoCaptureMixin, IterableCameraMixin, BaseCamera, ViewableCameraM
         self.video_capture.release()
 
     @classmethod
-    def discover(cls, **kwargs: Any) -> Generator["Camera", None, None]:
+    def discover(cls, **kwargs: Any) -> Generator[Camera, None, None]:
         for camera_id in find_camera_ids():
             yield cls(camera_id, **kwargs)
 
@@ -99,10 +99,10 @@ class SnapshotCamera(VideoCaptureMixin, BaseCamera):
         self,
         camera_id: int,
         *,
-        marker_size: Optional[int] = None,
+        marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Optional[Path] = None,
-        resolution: Optional[Tuple[int, int]] = None,
+        calibration_file: Path | None = None,
+        resolution: tuple[int, int] | None = None,
     ) -> None:
         super().__init__(
             marker_size=marker_size,
@@ -128,7 +128,7 @@ class SnapshotCamera(VideoCaptureMixin, BaseCamera):
             )
         return video_capture
 
-    def get_resolution(self) -> Tuple[int, int]:
+    def get_resolution(self) -> tuple[int, int]:
         if self._resolution is None:
             raise ValueError(
                 "Cannot find resolution of camera until at least 1 frame has been captured."
@@ -142,6 +142,6 @@ class SnapshotCamera(VideoCaptureMixin, BaseCamera):
         return frame
 
     @classmethod
-    def discover(cls, **kwargs: Any) -> Generator["SnapshotCamera", None, None]:
+    def discover(cls, **kwargs: Any) -> Generator[SnapshotCamera, None, None]:
         for camera_id in find_camera_ids():
             yield cls(camera_id, **kwargs)

--- a/zoloto/cameras/camera.py
+++ b/zoloto/cameras/camera.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Generator, Optional, Tuple
 

--- a/zoloto/cameras/file.py
+++ b/zoloto/cameras/file.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Generator, Optional, Tuple
+from typing import Generator
 
 from cv2 import VideoCapture, imread
 from numpy.typing import NDArray

--- a/zoloto/cameras/file.py
+++ b/zoloto/cameras/file.py
@@ -22,9 +22,9 @@ class ImageFileCamera(BaseCamera):
         self,
         image_path: Path,
         *,
-        marker_size: Optional[int] = None,
+        marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Optional[Path] = None,
+        calibration_file: Path | None = None,
     ) -> None:
         self.image_path = image_path
         super().__init__(
@@ -47,9 +47,9 @@ class VideoFileCamera(
         self,
         video_path: Path,
         *,
-        marker_size: Optional[int] = None,
+        marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Optional[Path] = None,
+        calibration_file: Path | None = None,
     ) -> None:
         super().__init__(
             marker_size=marker_size,
@@ -71,7 +71,7 @@ class VideoFileCamera(
         super().close()
         self.video_capture.release()
 
-    def get_resolution(self) -> Tuple[int, int]:
+    def get_resolution(self) -> tuple[int, int]:
         return get_video_capture_resolution(self.video_capture)
 
     def __iter__(self) -> Generator[NDArray, None, None]:

--- a/zoloto/cameras/file.py
+++ b/zoloto/cameras/file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Generator, Optional, Tuple
 

--- a/zoloto/cameras/marker.py
+++ b/zoloto/cameras/marker.py
@@ -41,7 +41,7 @@ class MarkerCamera(BaseCamera):
 
         if border_size < self.MIN_BORDER_SIZE:
             raise ValueError(
-                f"Border size must be at least {self.MIN_BORDER_SIZE}"
+                f"Border size must be at least {self.MIN_BORDER_SIZE}",
             )
 
         super().__init__(

--- a/zoloto/cameras/marker.py
+++ b/zoloto/cameras/marker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import cv2

--- a/zoloto/cameras/marker.py
+++ b/zoloto/cameras/marker.py
@@ -43,7 +43,7 @@ class MarkerCamera(BaseCamera):
 
         if border_size < self.MIN_BORDER_SIZE:
             raise ValueError(
-                "Border size must be at least {}".format(self.MIN_BORDER_SIZE)
+                f"Border size must be at least {self.MIN_BORDER_SIZE}"
             )
 
         super().__init__(
@@ -57,7 +57,7 @@ class MarkerCamera(BaseCamera):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.marker_id} size={self._marker_size} type={self.marker_type.name}>"
 
-    def get_resolution(self) -> Tuple[int, int]:
+    def get_resolution(self) -> tuple[int, int]:
         size = int(self.get_marker_size(self.marker_id) + self.border_size * 2)
         return size, size
 

--- a/zoloto/cameras/marker.py
+++ b/zoloto/cameras/marker.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 import cv2
 from numpy.typing import NDArray
 

--- a/zoloto/cameras/mixins.py
+++ b/zoloto/cameras/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Iterator
 

--- a/zoloto/cameras/rpi.py
+++ b/zoloto/cameras/rpi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Optional
 

--- a/zoloto/cameras/rpi.py
+++ b/zoloto/cameras/rpi.py
@@ -17,9 +17,9 @@ class PiCamera(IterableCameraMixin, BaseCamera, ViewableCameraMixin):
     def __init__(
         self,
         *,
-        marker_size: Optional[int] = None,
+        marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Optional[Path] = None
+        calibration_file: Path | None = None
     ) -> None:
         super().__init__(
             marker_size=marker_size,

--- a/zoloto/cameras/rpi.py
+++ b/zoloto/cameras/rpi.py
@@ -18,7 +18,7 @@ class PiCamera(IterableCameraMixin, BaseCamera, ViewableCameraMixin):
         *,
         marker_size: int | None = None,
         marker_type: MarkerType,
-        calibration_file: Path | None = None
+        calibration_file: Path | None = None,
     ) -> None:
         super().__init__(
             marker_size=marker_size,

--- a/zoloto/cameras/rpi.py
+++ b/zoloto/cameras/rpi.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 import picamera
 import picamera.array

--- a/zoloto/cameras/utils.py
+++ b/zoloto/cameras/utils.py
@@ -8,7 +8,7 @@ from cv2 import CAP_PROP_FRAME_HEIGHT, CAP_PROP_FRAME_WIDTH, VideoCapture
 from zoloto.calibration import CalibrationParameters
 
 
-def get_video_capture_resolution(video_capture: VideoCapture) -> Tuple[int, int]:
+def get_video_capture_resolution(video_capture: VideoCapture) -> tuple[int, int]:
     return (
         int(video_capture.get(CAP_PROP_FRAME_WIDTH)),
         int(video_capture.get(CAP_PROP_FRAME_HEIGHT)),
@@ -16,7 +16,7 @@ def get_video_capture_resolution(video_capture: VideoCapture) -> Tuple[int, int]
 
 
 def set_video_capture_resolution(
-    video_capture: VideoCapture, resolution: Tuple[int, int]
+    video_capture: VideoCapture, resolution: tuple[int, int]
 ) -> None:
     video_capture.set(CAP_PROP_FRAME_WIDTH, resolution[0])
     video_capture.set(CAP_PROP_FRAME_HEIGHT, resolution[1])

--- a/zoloto/cameras/utils.py
+++ b/zoloto/cameras/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from typing import Tuple
 

--- a/zoloto/cameras/utils.py
+++ b/zoloto/cameras/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import Tuple
 
 from cv2 import CAP_PROP_FRAME_HEIGHT, CAP_PROP_FRAME_WIDTH, VideoCapture
 

--- a/zoloto/cli/__init__.py
+++ b/zoloto/cli/__init__.py
@@ -28,7 +28,7 @@ def get_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers()
     for command in __all__:
-        name = "{}.{}".format(__name__, command)
+        name = f"{__name__}.{command}"
         importlib.import_module(name).add_subparser(subparsers)
 
     return parser

--- a/zoloto/cli/__init__.py
+++ b/zoloto/cli/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import importlib
 

--- a/zoloto/cli/annotate_image.py
+++ b/zoloto/cli/annotate_image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 

--- a/zoloto/cli/annotate_image.py
+++ b/zoloto/cli/annotate_image.py
@@ -14,7 +14,7 @@ def main(args: argparse.Namespace) -> None:
         camera.save_frame(Path(args.out_file), annotate=True)
 
         print(  # noqa: T001
-            "Saw {} markers in this image".format(len(camera.get_visible_markers()))
+            f"Saw {len(camera.get_visible_markers())} markers in this image"
         )
 
 

--- a/zoloto/cli/annotate_video.py
+++ b/zoloto/cli/annotate_video.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 

--- a/zoloto/cli/count_markers.py
+++ b/zoloto/cli/count_markers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 

--- a/zoloto/cli/marker_details.py
+++ b/zoloto/cli/marker_details.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 from zoloto.marker_type import MarkerType

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -33,7 +33,7 @@ class PageSize(Enum):
     A4 = (210, 297)
 
     @property
-    def pixels(self) -> Tuple[int, int]:
+    def pixels(self) -> tuple[int, int]:
         return (
             mm_to_pixels(self.value[0]),
             mm_to_pixels(self.value[1]),
@@ -171,7 +171,7 @@ def main(args: argparse.Namespace) -> None:
 
                 print("Saving", marker_id)  # noqa:T001
                 paper_img_1.save(
-                    output_dir / "{}.pdf".format(marker_id),
+                    output_dir / f"{marker_id}.pdf",
                     "PDF",
                     quality=100,
                     dpi=(DPI, DPI),
@@ -194,7 +194,7 @@ def main(args: argparse.Namespace) -> None:
 
                 print("Saving", marker_id)  # noqa:T001
                 paper_img.save(
-                    output_dir / "{}.pdf".format(marker_id),
+                    output_dir / f"{marker_id}.pdf",
                     "PDF",
                     quality=100,
                     dpi=(DPI, DPI),

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from enum import Enum
 from pathlib import Path

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 from enum import Enum
 from pathlib import Path
-from typing import Tuple
 
 from zoloto.cameras.marker import MarkerCamera
 from zoloto.marker_type import MARKER_TYPE_NAMES, MarkerType

--- a/zoloto/cli/preview.py
+++ b/zoloto/cli/preview.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 from zoloto.cameras.camera import Camera

--- a/zoloto/cli/save_markers.py
+++ b/zoloto/cli/save_markers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 

--- a/zoloto/cli/save_markers.py
+++ b/zoloto/cli/save_markers.py
@@ -29,7 +29,7 @@ def main(args: argparse.Namespace) -> None:
             print("Saving", marker_id)  # noqa:T001
 
             if args.raw:
-                camera.save_frame(output_dir / "{}.png".format(marker_id))
+                camera.save_frame(output_dir / f"{marker_id}.png")
             else:
                 image = Image.fromarray(camera.capture_frame())
 
@@ -45,7 +45,7 @@ def main(args: argparse.Namespace) -> None:
                     ),
                     anchor="lt",
                 )
-                resized_image.save(output_dir / "{}.png".format(marker_id))
+                resized_image.save(output_dir / f"{marker_id}.png")
 
 
 def add_subparser(subparsers: argparse._SubParsersAction) -> None:

--- a/zoloto/cli/validate_calibration.py
+++ b/zoloto/cli/validate_calibration.py
@@ -43,7 +43,7 @@ def is_valid_calibration(filename: Path) -> bool:
     return True
 
 
-def main(args: argparse.Namespace) -> Optional[int]:
+def main(args: argparse.Namespace) -> int | None:
     if is_valid_calibration(args.file):
         print("Calibration is valid")  # noqa:T001
         return None

--- a/zoloto/cli/validate_calibration.py
+++ b/zoloto/cli/validate_calibration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import tempfile
 from pathlib import Path
-from typing import Optional
 
 from zoloto.calibration import parse_calibration_file
 from zoloto.cameras.file import ImageFileCamera

--- a/zoloto/cli/validate_calibration.py
+++ b/zoloto/cli/validate_calibration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import tempfile
 from pathlib import Path

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterator, NamedTuple, Tuple
 
 from cached_property import cached_property

--- a/zoloto/exceptions.py
+++ b/zoloto/exceptions.py
@@ -14,6 +14,6 @@ class MissingCalibrationsError(ZolotoException):
 
 
 class CameraReadError(ZolotoException):
-    def __init__(self, frame: Optional[NDArray]):
+    def __init__(self, frame: NDArray | None):
         self.frame = frame
         super().__init__()

--- a/zoloto/exceptions.py
+++ b/zoloto/exceptions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from numpy.typing import NDArray
 
 

--- a/zoloto/exceptions.py
+++ b/zoloto/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from numpy.typing import NDArray

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple
 

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -18,7 +18,7 @@ from .marker_type import MarkerType
 
 class BaseMarker(ABC):
     def __init__(
-        self, marker_id: int, corners: List[NDArray], size: int, marker_type: MarkerType
+        self, marker_id: int, corners: list[NDArray], size: int, marker_type: MarkerType
     ):
         self.__id = marker_id
         self._pixel_corners = corners
@@ -29,7 +29,7 @@ class BaseMarker(ABC):
         return f"<{self.__class__.__name__} id={self.id} size={self.size} type={self.marker_type.name}>"
 
     @abstractmethod
-    def _get_pose_vectors(self) -> Tuple[NDArray, NDArray]:  # pragma: nocover
+    def _get_pose_vectors(self) -> tuple[NDArray, NDArray]:  # pragma: nocover
         raise NotImplementedError()
 
     @property  # noqa: A003
@@ -45,7 +45,7 @@ class BaseMarker(ABC):
         return self.__marker_type
 
     @property
-    def pixel_corners(self) -> List[Coordinates]:
+    def pixel_corners(self) -> list[Coordinates]:
         return [Coordinates(x=float(x), y=float(y)) for x, y in self._pixel_corners]
 
     @cached_property
@@ -83,7 +83,7 @@ class BaseMarker(ABC):
     def _tvec(self) -> NDArray:
         return self._get_pose_vectors()[1]
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         marker_dict = {
             "id": self.id,
             "size": self.size,
@@ -102,10 +102,10 @@ class EagerMarker(BaseMarker):
     def __init__(
         self,
         marker_id: int,
-        corners: List[NDArray],
+        corners: list[NDArray],
         size: int,
         marker_type: MarkerType,
-        precalculated_vectors: Tuple[NDArray, NDArray],
+        precalculated_vectors: tuple[NDArray, NDArray],
     ):
         super().__init__(marker_id, corners, size, marker_type)
         self.__precalculated_vectors = precalculated_vectors
@@ -113,7 +113,7 @@ class EagerMarker(BaseMarker):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} size={self.size} type={self.marker_type.name} distance={self.distance}>"
 
-    def _get_pose_vectors(self) -> Tuple[NDArray, NDArray]:
+    def _get_pose_vectors(self) -> tuple[NDArray, NDArray]:
         return self.__precalculated_vectors
 
 
@@ -121,7 +121,7 @@ class Marker(BaseMarker):
     def __init__(
         self,
         marker_id: int,
-        corners: List[NDArray],
+        corners: list[NDArray],
         size: int,
         marker_type: MarkerType,
         calibration_params: CalibrationParameters,
@@ -130,7 +130,7 @@ class Marker(BaseMarker):
         self.__calibration_params = calibration_params
 
     @cached_method
-    def _get_pose_vectors(self) -> Tuple[NDArray, NDArray]:
+    def _get_pose_vectors(self) -> tuple[NDArray, NDArray]:
         rvec, tvec, _ = aruco.estimatePoseSingleMarkers(
             [self._pixel_corners],
             self.size,
@@ -141,5 +141,5 @@ class Marker(BaseMarker):
 
 
 class UncalibratedMarker(BaseMarker):
-    def _get_pose_vectors(self) -> Tuple[NDArray, NDArray]:
+    def _get_pose_vectors(self) -> tuple[NDArray, NDArray]:
         raise MissingCalibrationsError()

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from cached_property import cached_property
 from cv2 import aruco

--- a/zoloto/marker_type.py
+++ b/zoloto/marker_type.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import IntEnum
 from typing import List
 

--- a/zoloto/marker_type.py
+++ b/zoloto/marker_type.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import List
 
 from cv2 import aruco, aruco_Dictionary
 

--- a/zoloto/marker_type.py
+++ b/zoloto/marker_type.py
@@ -53,7 +53,7 @@ class MarkerType(IntEnum):
         return self.dictionary.markerSize
 
     @property
-    def marker_ids(self) -> List[int]:
+    def marker_ids(self) -> list[int]:
         """
         All of the possible marker ids
         """

--- a/zoloto/utils.py
+++ b/zoloto/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, List, Set, TypeVar
+from typing import Any, Callable, TypeVar
 
 T = TypeVar("T", bound=Callable[[Any], Any])
 

--- a/zoloto/utils.py
+++ b/zoloto/utils.py
@@ -22,13 +22,13 @@ def cached_method(f: T) -> T:
     return wrapper  # type: ignore[return-value]
 
 
-def parse_ranges(ranges: str) -> Set[int]:
+def parse_ranges(ranges: str) -> set[int]:
     """
     Parse a comma seprated list of numbers which may include ranges
     specified as hyphen-separated numbers.
     From https://stackoverflow.com/questions/6405208
     """
-    result: List[int] = []
+    result: list[int] = []
     for part in ranges.split(","):
         if "-" in part:
             a_, b_ = part.split("-")

--- a/zoloto/utils.py
+++ b/zoloto/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 from typing import Any, Callable, List, Set, TypeVar
 


### PR DESCRIPTION
This uses a combination of `com2ann`, a bash one-liner and `pyupgrade` and `fix8` to upgrade to modern Python syntax, mostly around type annotations.