### PR TITLE
Clarify that 'zoloto preview' requires a '--type'

### DIFF
--- a/zoloto/cli/preview.py
+++ b/zoloto/cli/preview.py
@@ -22,5 +22,6 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         type=str,
         choices=sorted(MARKER_TYPE_NAMES),
         help="Marker dictionary",
+        required=True,
     )
     parser.set_defaults(func=main)


### PR DESCRIPTION
Without this the type is `None`, which then throws an unhelpful exception (a `KeyError`).