### PR TITLE
Fix detection of generated marker PDFs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,4 +20,3 @@ sphinx==4.2.0
 sphinx-rtd-theme==1.0.0
 sphinx_autodoc_typehints==1.12.0
 m2r2==0.3.2
-pdf2image==1.16.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,3 +20,4 @@ sphinx==4.2.0
 sphinx-rtd-theme==1.0.0
 sphinx_autodoc_typehints==1.12.0
 m2r2==0.3.2
+pdf2image==1.16.0

--- a/stubs/cv2/__init__.pyi
+++ b/stubs/cv2/__init__.pyi
@@ -17,7 +17,7 @@ FILE_STORAGE_READ: int
 BORDER_CONSTANT: int
 
 class aruco_DetectorParameters:
-    pass
+    minMarkerDistanceRate: float
 
 class FileNode:
     def mat(self) -> NDArray: ...

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import cv2
 import pytest
 
 from zoloto.cameras.file import ImageFileCamera
@@ -25,20 +24,7 @@ def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
     )
     rtn.check_returncode()
 
-    class CustomImageCamera(ImageFileCamera):
-        def get_detector_params(self) -> cv2.aruco_DetectorParameters:
-            """
-            Slightly tweak `minMarkerDistanceRate` to prevent the border superseding
-            the marker edge during contour refinement.
-
-            In reality, the border is removed during adaptive thresholding,
-            however this isn't possible given just the PDF page.
-            """
-            detector_params = super().get_detector_params()
-            detector_params.minMarkerDistanceRate = 0.035
-            return detector_params
-
-    image_file_camera = CustomImageCamera(tmp_path / "0.png", marker_type=marker_type)
+    image_file_camera = ImageFileCamera(tmp_path / "0.png", marker_type=marker_type)
     assert image_file_camera.get_visible_markers() == [0]
 
 

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+from pdf2image import convert_from_path
+
+from zoloto.cameras.file import ImageFileCamera
 from zoloto.marker_type import MarkerType
 
 from . import call_cli
@@ -10,3 +14,14 @@ def test_creates_correct_number_of_pdfs(tmp_path: Path) -> None:
     rtn.check_returncode()
     pdfs = list(tmp_path.glob("*.pdf"))
     assert len(pdfs) == MarkerType.APRILTAG_16H5.marker_count
+
+
+@pytest.mark.parametrize("marker_type", MarkerType)
+def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
+    rtn = call_cli(
+        ["marker-pdfs", marker_type.name, str(tmp_path), "100", "--range", "0"]
+    )
+    rtn.check_returncode()
+    convert_from_path(tmp_path / "0.pdf")[0].save(tmp_path / "0.png")
+    image_file_camera = ImageFileCamera(tmp_path / "0.png", marker_type=marker_type)
+    assert image_file_camera.get_visible_markers() == [0]

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -10,11 +10,14 @@ from zoloto.marker_type import MarkerType
 from . import call_cli
 
 
-def test_creates_correct_number_of_pdfs(tmp_path: Path) -> None:
-    rtn = call_cli(["marker-pdfs", "APRILTAG_16H5", str(tmp_path), "100"])
+@pytest.mark.parametrize("marker_type", MarkerType)
+def test_creates_correct_number_of_pdfs(
+    marker_type: MarkerType, tmp_path: Path
+) -> None:
+    rtn = call_cli(["marker-pdfs", marker_type.name, str(tmp_path), "100"])
     rtn.check_returncode()
     pdfs = list(tmp_path.glob("*.pdf"))
-    assert len(pdfs) == MarkerType.APRILTAG_16H5.marker_count
+    assert len(pdfs) == marker_type.marker_count
 
 
 @pytest.mark.parametrize("marker_type", MarkerType)

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import cv2
 import pytest
-from pdf2image import convert_from_path
 
 from zoloto.cameras.file import ImageFileCamera
 from zoloto.marker_type import MarkerType
@@ -23,7 +22,16 @@ def test_creates_correct_number_of_pdfs(
 @pytest.mark.parametrize("marker_type", MarkerType)
 def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
     rtn = call_cli(
-        ["marker-pdfs", marker_type.name, str(tmp_path), "100", "--range", "0"]
+        [
+            "marker-pdfs",
+            marker_type.name,
+            str(tmp_path),
+            "100",
+            "--range",
+            "0",
+            "--filename",
+            "{id}.png",  # HACK: Pretend the output is a PNG for the sake of tests
+        ]
     )
     rtn.check_returncode()
 
@@ -40,7 +48,6 @@ def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
             detector_params.minMarkerDistanceRate = 0.035
             return detector_params
 
-    convert_from_path(tmp_path / "0.pdf")[0].save(tmp_path / "0.png")
     image_file_camera = CustomImageCamera(tmp_path / "0.png", marker_type=marker_type)
     assert image_file_camera.get_visible_markers() == [0]
 
@@ -63,10 +70,10 @@ def test_detectable_without_border(marker_type: MarkerType, tmp_path: Path) -> N
             "0",
             "--border-size",
             "0",
+            "--filename",
+            "{id}.png",  # HACK: Pretend the output is a PNG for the sake of tests
         ]
     )
     rtn.check_returncode()
-
-    convert_from_path(tmp_path / "0.pdf")[0].save(tmp_path / "0.png")
     image_file_camera = ImageFileCamera(tmp_path / "0.png", marker_type=marker_type)
     assert image_file_camera.get_visible_markers() == [0]

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -10,16 +10,6 @@ from . import call_cli
 
 
 @pytest.mark.parametrize("marker_type", MarkerType)
-def test_creates_correct_number_of_pdfs(
-    marker_type: MarkerType, tmp_path: Path
-) -> None:
-    rtn = call_cli(["marker-pdfs", marker_type.name, str(tmp_path), "100"])
-    rtn.check_returncode()
-    pdfs = list(tmp_path.glob("*.pdf"))
-    assert len(pdfs) == marker_type.marker_count
-
-
-@pytest.mark.parametrize("marker_type", MarkerType)
 def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
     rtn = call_cli(
         [

--- a/tests/test_cli/test_marker_pdfs.py
+++ b/tests/test_cli/test_marker_pdfs.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import cv2
 import pytest
 from pdf2image import convert_from_path
 
@@ -22,6 +23,47 @@ def test_detectable(marker_type: MarkerType, tmp_path: Path) -> None:
         ["marker-pdfs", marker_type.name, str(tmp_path), "100", "--range", "0"]
     )
     rtn.check_returncode()
+
+    class CustomImageCamera(ImageFileCamera):
+        def get_detector_params(self) -> cv2.aruco_DetectorParameters:
+            """
+            Slightly tweak `minMarkerDistanceRate` to prevent the border superseding
+            the marker edge during contour refinement.
+
+            In reality, the border is removed during adaptive thresholding,
+            however this isn't possible given just the PDF page.
+            """
+            detector_params = super().get_detector_params()
+            detector_params.minMarkerDistanceRate = 0.035
+            return detector_params
+
+    convert_from_path(tmp_path / "0.pdf")[0].save(tmp_path / "0.png")
+    image_file_camera = CustomImageCamera(tmp_path / "0.png", marker_type=marker_type)
+    assert image_file_camera.get_visible_markers() == [0]
+
+
+@pytest.mark.parametrize("marker_type", MarkerType)
+def test_detectable_without_border(marker_type: MarkerType, tmp_path: Path) -> None:
+    """
+    Confirm that, if the border is removed, the marker is detected.
+
+    In reality, the border is removed during adaptive thresholding,
+    however this isn't possible given just the PDF page.
+    """
+    rtn = call_cli(
+        [
+            "marker-pdfs",
+            marker_type.name,
+            str(tmp_path),
+            "100",
+            "--range",
+            "0",
+            "--border-size",
+            "0",
+        ]
+    )
+    rtn.check_returncode()
+
     convert_from_path(tmp_path / "0.pdf")[0].save(tmp_path / "0.png")
     image_file_camera = ImageFileCamera(tmp_path / "0.png", marker_type=marker_type)
     assert image_file_camera.get_visible_markers() == [0]

--- a/zoloto/cameras/base.py
+++ b/zoloto/cameras/base.py
@@ -32,7 +32,14 @@ class BaseCamera(ABC):
             self.calibration_params = parse_calibration_file(calibration_file)
 
     def get_detector_params(self) -> cv2.aruco_DetectorParameters:
-        return cv2.aruco.DetectorParameters_create()
+        """
+        Note: We modify the default parameters slightly to improve detection
+        on markers with hard borders (like the ones generated from
+        `zoloto marker-pdfs`)
+        """
+        parameters = cv2.aruco.DetectorParameters_create()
+        parameters.minMarkerDistanceRate = 0.035
+        return parameters
 
     def get_marker_size(self, marker_id: int) -> int:
         if self._marker_size is None:

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -175,7 +175,7 @@ def main(args: argparse.Namespace) -> None:
 
                 print("Saving marker", marker_id)  # noqa:T001
                 paper_img_1.save(
-                    output_dir / args.filename.format(marker_id),
+                    output_dir / args.filename.format(id=marker_id),
                     quality=100,
                     dpi=(DPI, DPI),
                     save_all=True,

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -8,7 +8,6 @@ from zoloto.marker_type import MARKER_TYPE_NAMES, MarkerType
 from zoloto.utils import parse_ranges
 
 DPI = 72
-BORDER_SIZE = 2
 BORDER_FILL = "grey"
 CENTER_LINE_SIZE = 16
 
@@ -55,11 +54,11 @@ def main(args: argparse.Namespace) -> None:
     pixel_size = args.size // marker_type.min_marker_image_size
     required_size = args.size + (pixel_size * 2)
 
-    if args.size + BORDER_SIZE * 2 > min(page_size.value):
+    if args.size + args.border_size * 2 > min(page_size.value):
         print(  # noqa:T001
             f"Warning: Marker size is too large to fit on {args.page_size}"
         )
-    elif required_size + BORDER_SIZE * 2 > min(page_size.value):
+    elif required_size + args.border_size * 2 > min(page_size.value):
         print(  # noqa:T001
             f"Warning: Marker size is too large to fit on {args.page_size} with border"
         )
@@ -82,7 +81,7 @@ def main(args: argparse.Namespace) -> None:
 
             # Add a border to the marker, which includes padding
             bordered_image = ImageOps.expand(
-                resized_image, border=BORDER_SIZE, fill=BORDER_FILL
+                resized_image, border=args.border_size, fill=BORDER_FILL
             )
             img_size = bordered_image.size[0]
 
@@ -97,19 +96,19 @@ def main(args: argparse.Namespace) -> None:
 
             # Add center lines
             if not args.no_center_lines:
-                line_start = (img_size // 2) - (BORDER_SIZE // 2)
+                line_start = (img_size // 2) - (args.border_size // 2)
 
                 # Top
                 image_draw.line(
                     [line_start, 0, line_start, CENTER_LINE_SIZE],
-                    width=BORDER_SIZE,
+                    width=args.border_size,
                     fill=BORDER_FILL,
                 )
 
                 # Left
                 image_draw.line(
                     [0, line_start, CENTER_LINE_SIZE, line_start],
-                    width=BORDER_SIZE,
+                    width=args.border_size,
                     fill=BORDER_FILL,
                 )
 
@@ -121,7 +120,7 @@ def main(args: argparse.Namespace) -> None:
                         line_start,
                         img_size,
                     ],
-                    width=BORDER_SIZE,
+                    width=args.border_size,
                     fill=BORDER_FILL,
                 )
 
@@ -133,7 +132,7 @@ def main(args: argparse.Namespace) -> None:
                         img_size,
                         line_start,
                     ],
-                    width=BORDER_SIZE,
+                    width=args.border_size,
                     fill=BORDER_FILL,
                 )
 
@@ -246,5 +245,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--no-center-lines",
         help="Do not output center lines around the border",
         action="store_true",
+    )
+    parser.add_argument(
+        "--border-size",
+        help="Size of the border (and center lines) in pixels. Note that the border expands from center (default: %(default)s)",
+        default=2,
+        type=int,
     )
     parser.set_defaults(func=main)

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -8,7 +8,7 @@ from zoloto.marker_type import MARKER_TYPE_NAMES, MarkerType
 from zoloto.utils import parse_ranges
 
 DPI = 72
-BORDER_FILL = "grey"
+BORDER_FILL = "lightgrey"
 
 
 def mm_to_inches(mm: int) -> float:

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -9,7 +9,6 @@ from zoloto.utils import parse_ranges
 
 DPI = 72
 BORDER_FILL = "grey"
-CENTER_LINE_SIZE = 16
 
 
 def mm_to_inches(mm: int) -> float:
@@ -63,6 +62,13 @@ def main(args: argparse.Namespace) -> None:
             f"Warning: Marker size is too large to fit on {args.page_size} with border"
         )
 
+    if (
+        args.border_size
+        and args.center_line_length
+        and args.border_size > args.center_line_length
+    ):
+        print("Warning: center lines may not be visible")  # noqa:T001
+
     marker_ids = (
         parse_ranges(args.range) if args.range != "ALL" else marker_type.marker_ids
     )
@@ -95,19 +101,19 @@ def main(args: argparse.Namespace) -> None:
             )
 
             # Add center lines
-            if not args.no_center_lines:
+            if args.center_line_length:
                 line_start = (img_size // 2) - (args.border_size // 2)
 
                 # Top
                 image_draw.line(
-                    [line_start, 0, line_start, CENTER_LINE_SIZE],
+                    [line_start, 0, line_start, args.center_line_length],
                     width=args.border_size,
                     fill=BORDER_FILL,
                 )
 
                 # Left
                 image_draw.line(
-                    [0, line_start, CENTER_LINE_SIZE, line_start],
+                    [0, line_start, args.center_line_length, line_start],
                     width=args.border_size,
                     fill=BORDER_FILL,
                 )
@@ -116,7 +122,7 @@ def main(args: argparse.Namespace) -> None:
                 image_draw.line(
                     [
                         line_start,
-                        img_size - CENTER_LINE_SIZE,
+                        img_size - args.center_line_length,
                         line_start,
                         img_size,
                     ],
@@ -127,7 +133,7 @@ def main(args: argparse.Namespace) -> None:
                 # Right
                 image_draw.line(
                     [
-                        img_size - CENTER_LINE_SIZE,
+                        img_size - args.center_line_length,
                         line_start,
                         img_size,
                         line_start,
@@ -242,9 +248,10 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
     )
     parser.add_argument(
-        "--no-center-lines",
-        help="Do not output center lines around the border",
-        action="store_true",
+        "--center-line-length",
+        help="Length of center lines in pixels (default: %(default)s)",
+        default=10,
+        type=int,
     )
     parser.add_argument(
         "--border-size",

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -260,7 +260,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "--border-size",
         help="Size of the border (and center lines) in pixels. Note that the border expands from center (default: %(default)s)",
-        default=2,
+        default=1,
         type=int,
     )
     parser.set_defaults(func=main)

--- a/zoloto/cli/marker_pdfs.py
+++ b/zoloto/cli/marker_pdfs.py
@@ -172,10 +172,9 @@ def main(args: argparse.Namespace) -> None:
                     ),
                 )
 
-                print("Saving", marker_id)  # noqa:T001
+                print("Saving marker", marker_id)  # noqa:T001
                 paper_img_1.save(
-                    output_dir / "{}.pdf".format(marker_id),
-                    "PDF",
+                    output_dir / args.filename.format(marker_id),
                     quality=100,
                     dpi=(DPI, DPI),
                     save_all=True,
@@ -195,10 +194,9 @@ def main(args: argparse.Namespace) -> None:
                     ),
                 )
 
-                print("Saving", marker_id)  # noqa:T001
+                print("Saving marker", marker_id)  # noqa:T001
                 paper_img.save(
-                    output_dir / "{}.pdf".format(marker_id),
-                    "PDF",
+                    output_dir / args.filename.format(id=marker_id),
                     quality=100,
                     dpi=(DPI, DPI),
                 )
@@ -223,6 +221,12 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "size",
         type=float,
         help="Size of marker (mm)",
+    )
+    parser.add_argument(
+        "--filename",
+        type=str,
+        help="Output filename. `id` is available for string format replacement (default: %(default)s)",
+        default="{id}.pdf",
     )
     parser.add_argument(
         "--description-format",


### PR DESCRIPTION
This is a fairly simple fix, but there's some backstory. _Stay a while and listen_:

Marker PDFs add a border to the resulting PDFs. The aim of this was to help lining up, and ensure a high-contrast border for the marker (on top of the black border it already has). Additionally, a few small notches are added showing the center of the marker, which is useful for alignment.

After some testing, it turns out this border is actually quite a hindrance, and can drastically affect the chances of detecting a marker.

As part of the marker detection, OpenCV performs "contour detection and refinement", where it searches for squares with well defined edges to attempt to decode into markers. If 2 contours are too close together, and fully contained within eachother, the larger contour is kept. When marker detection failed, it was because the border was superseding the actual marker edge as a contour candidate, which was then rejected later when it came to decoding.

This could be considered a limitation of OpenCV, whereby a smaller valid contour is rejected for a larger potentially-invalid one. However, OpenCV has a tunable for this: `minMarkerDistanceRate`:

> Minimum distance between any pair of corners from two different markers. It is expressed relative to the minimum marker perimeter of the two markers. If two candidates are too close, the smaller one is ignored.

Its default value isn't quite enough to separate the marker and its border as different contours. In testing, tweaking this value (as little as 10-20%) improved reliability to the point of working as expected. If adjusted too low, it results in markers appearing multiple times, but this required drastic changes (around 1000%) to occur.

This also explains why we saw better detection of markers at a larger distance, or when moving. Because at distance, the border is imperceptible and excluded during adaptive thresholding. Similar is true when moving, where the hard edge of the border is disrupted enough to not be considered a contour. We also saw this be unreliable, likely due to whether the border was covered by any mounting tape or not.

The solution proposed here is two-fold:

- Lighten the marker border, such that it's much more likely to be removed during thresholding / under real-world lighting conditions. Changing this from `#808080` to `#d3d3d3` seemed to reliably and consistently improve detection.
- Decrease the size of the border, for the same reasons as above. Making it lighter seems to help more, but in some situations thinning it out seems to help too. Exactly which makes the most difference depends on the lighting.

Additionally, it may be useful to weak the value of `minMarkerDistanceRate` downstream. I don't want to change the value by default, because it's important Zoloto remain unopinionated and uses the defaults. Setting this to even `0.035` drastically improves detection. Changing this theoretically reduces the need to recolour the border, as even if the border is seen, it doesn't affect the contour refinement.

Does that mean this PR is a 6-character change at its core? Yes. But the usability and testing improvements are worthwhile.